### PR TITLE
Accessibility via grid role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.tgz
 node_modules
 dist
+*.log

--- a/src/cell.js
+++ b/src/cell.js
@@ -8,6 +8,7 @@ export default function Cell(props) {
   return (
     <div
       className={props.className}
+      role="gridcell"
       {...eventHandlersFactory('Cell', ['Click'])}
     >
       {props.children}

--- a/src/cell.js
+++ b/src/cell.js
@@ -8,7 +8,7 @@ export default function Cell(props) {
   return (
     <div
       className={props.className}
-      role="gridcell"
+      role={props.role}
       {...eventHandlersFactory('Cell', ['Click'])}
     >
       {props.children}
@@ -18,9 +18,11 @@ export default function Cell(props) {
 
 Cell.defaultProps = {
   className: styles.container,
+  role: 'gridcell'
 };
 
 Cell.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node,
+  role: PropTypes.oneOf(['columnheader', 'gridcell']),
 };

--- a/src/data-tree.js
+++ b/src/data-tree.js
@@ -11,7 +11,7 @@ const subtreeChildren = new Array(subtreeLength).fill(0).map((_, index) => index
 
 export default function DataTree(props) {
   return (
-    <div>
+    <React.Fragment>
       <Grid
         key={props.id}
       >
@@ -38,7 +38,7 @@ export default function DataTree(props) {
           )}
         </Grid>
       )}
-    </div>
+    </React.Fragment>
   );
 };
 

--- a/src/grid.js
+++ b/src/grid.js
@@ -10,6 +10,7 @@ export default function Grid(props) {
     <div
       className={props.className}
       draggable
+      role="row"
       {...eventHandlersFactory('Grid', ['Click', 'Drag'])}
     >
       {props.children}

--- a/src/headings-grid.js
+++ b/src/headings-grid.js
@@ -12,6 +12,7 @@ export default function HeadingsGrid(props) {
         <Cell
           className={column.headingClassName || column.className}
           key={column.id}
+          role="columnheader"
         >
           {column.headingNode}
         </Cell>

--- a/src/tree-grid.js
+++ b/src/tree-grid.js
@@ -9,7 +9,10 @@ import styles from './tree-grid.css'
 
 export default function TreeGrid(props) {
   return (
-    <div className={styles.container}>
+    <div
+      className={styles.container}
+      role="grid"
+    >
       <HeadingsGrid columns={props.columns} />
       {props.data.map(datum =>
         <DataTree


### PR DESCRIPTION
Implements core accessibility functionality with the `grid` role.

We tried using the `treegrid` role but the OSX VoiceOver application was not able to recognize the "table." It is preferable to incrementally add accessibility features -- no ARIA is better than bad ARIA. 

This PR adds navigation and the column relationships between header cells and body cells.

Given this work, I might consider renaming the components to their accessibility roles.