### PR TITLE
Tabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6212,11 +6212,6 @@
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
     },
-    "lodash.uniqueid": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.uniqueid/-/lodash.uniqueid-4.0.1.tgz",
-      "integrity": "sha1-MmjyanyI5PSxdY1nknGBTjH6WyY="
-    },
     "log-symbols": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6212,6 +6212,11 @@
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
     },
+    "lodash.uniqueid": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.uniqueid/-/lodash.uniqueid-4.0.1.tgz",
+      "integrity": "sha1-MmjyanyI5PSxdY1nknGBTjH6WyY="
+    },
     "log-symbols": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.2",
   "description": "",
   "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/juanca/react-aria-components"
+  },
   "scripts": {
     "start": "webpack-serve",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
     "webpack": "^4.8.3",
     "webpack-cli": "^2.1.4",
     "webpack-serve": "^1.0.2"
+  },
+  "dependencies": {
+    "lodash.uniqueid": "^4.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,8 +33,5 @@
     "webpack": "^4.8.3",
     "webpack-cli": "^2.1.4",
     "webpack-serve": "^1.0.2"
-  },
-  "dependencies": {
-    "lodash.uniqueid": "^4.0.1"
   }
 }

--- a/src/examples/index.js
+++ b/src/examples/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { render } from 'react-dom';
 
 import GridExample from './grid-example.js';
+import TabsExample from './tabs-example.js';
 import styles from './index.css';
 
 setTimeout(_ => {
@@ -14,6 +15,7 @@ setTimeout(_ => {
         </ol>
       </div>
       <GridExample />
+      <TabsExample />
     </React.Fragment>
   ), document.getElementById('page'));
 }, 100);

--- a/src/examples/tabs-example.js
+++ b/src/examples/tabs-example.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import Tabs from '../tabs.js';
+import TabList from '../tab-list.js';
+import Tab from '../tab.js';
+import TabPanels from '../tab-panels.js';
+
+export default class extends React.Component {
+  constructor() {
+    super();
+    this.state = { activeIndex: 0 };
+  }
+
+  render() {
+    return (
+      <Tabs activeIndex={this.state.activeIndex} onActivateTab={index => this.setState({ activeIndex: index })}>
+        <TabList>
+          <Tab>Tacos</Tab>
+          <Tab>Burritos</Tab>
+        </TabList>
+        <TabPanels>
+          <div>Delicious!</div>
+          <div>Just big tacos</div>
+        </TabPanels>
+      </Tabs>
+    );
+  }
+}

--- a/src/tab-list.js
+++ b/src/tab-list.js
@@ -1,0 +1,76 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export default class TabList extends React.Component {
+  constructor() {
+    super();
+    this.state = { focus: false };
+    this.handleBlur = this.handleBlur.bind(this);
+    this.handleKeyPress = this.handleKeyPress.bind(this);
+    this.handlers = {
+      ArrowLeft: this.previous.bind(this),
+      ArrowRight: this.next.bind(this),
+    };
+  }
+
+  wrapIndex(index) {
+    const count = React.Children.count(this.props.children);
+    return (index + count) % count;
+  }
+
+  handleBlur() {
+    this.setState({ focus: false });
+  }
+
+  handleKeyPress(event) {
+    const handler = this.handlers[event.key] || (() => {});
+    handler();
+  }
+
+  previous() {
+    const newIndex = this.wrapIndex(this.props.activeIndex - 1);
+    this.setState({ focus: true });
+    this.props.onActivateTab(newIndex)
+  }
+
+  next() {
+    const newIndex = this.wrapIndex(this.props.activeIndex + 1);
+    this.setState({ focus: true });
+    this.props.onActivateTab(newIndex)
+  }
+
+  render() {
+    const { accessibleId, activeIndex, children, className, onActivateTab } = this.props;
+
+    return (
+      <ul className={className} onBlur={this.handleBlur} onKeyUp={this.handleKeyPress} role="tablist">
+        {React.Children.map(children, (child, index) => {
+          const active = index === activeIndex;
+
+          return React.cloneElement(child, {
+            accessibleId: active ? accessibleId : undefined,
+            active,
+            focus: active && this.state.focus,
+            onActivate: () => this.props.onActivateTab(index),
+          });
+        })}
+      </ul>
+    );
+  }
+}
+
+TabList.propTypes = {
+  accessibleId: PropTypes.string,
+  activeIndex: PropTypes.number,
+  children: PropTypes.node,
+  className: PropTypes.string,
+  onActivateTab: PropTypes.func,
+};
+
+TabList.defaultProps = {
+  accessibleId: undefined,
+  activeIndex: 0,
+  children: null,
+  className: undefined,
+  onActivateTab: () => {},
+};

--- a/src/tab-panels.js
+++ b/src/tab-panels.js
@@ -1,0 +1,23 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export default function TabPanels({ accessibleId, activeIndex, children, className }) {
+  return (
+    <div aria-labelledby={accessibleId} role="tabpanel" className={className}>
+      {React.Children.toArray(children)[activeIndex]}
+    </div>
+  );
+}
+
+TabPanels.propTypes = {
+  accessibleId: PropTypes.string,
+  activeIndex: PropTypes.number,
+  children: PropTypes.node,
+  className: PropTypes.string,
+};
+
+TabPanels.defaultProps = {
+  accessibleId: undefined,
+  activeIndex: 0,
+  className: null,
+};

--- a/src/tab.js
+++ b/src/tab.js
@@ -1,0 +1,45 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export default function Tab({
+  accessibleId,
+  active,
+  activeClassName,
+  children,
+  focus,
+  inactiveClassName,
+  onActivate,
+}) {
+  return (
+    <li
+      aria-selected={active}
+      className={active ? activeClassName : inactiveClassName}
+      id={accessibleId}
+      onClick={onActivate}
+      ref={el => focus && el && el.focus()}
+      role="tab"
+      tabIndex={active ? 0 : undefined}
+    >
+      {children}
+    </li>
+  );
+}
+
+Tab.propTypes = {
+  accessibleId: PropTypes.string,
+  active: PropTypes.bool,
+  activeClassName: PropTypes.string,
+  children: PropTypes.node,
+  focus: PropTypes.bool,
+  inactiveClassName: PropTypes.string,
+  onActivate: PropTypes.func,
+};
+
+Tab.defaultProps = {
+  accessibleId: undefined,
+  active: false,
+  activeClassName: undefined,
+  focus: false,
+  inactiveClassName: undefined,
+  onActivate: undefined,
+};

--- a/src/tabs.js
+++ b/src/tabs.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import uniqueId from 'lodash.uniqueid';
+import uniqueId from './utils/unique-id';
 import TabList from './tab-list';
 import TabPanels from './tab-panels';
 

--- a/src/tabs.js
+++ b/src/tabs.js
@@ -7,7 +7,7 @@ import TabPanels from './tab-panels';
 export default class Tabs extends React.Component {
   constructor() {
     super();
-    this.accessibleId = uniqueId('rac-tabs-')
+    this.accessibleId = uniqueId();
   }
 
   render() {

--- a/src/tabs.js
+++ b/src/tabs.js
@@ -1,0 +1,47 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import uniqueId from 'lodash.uniqueid';
+import TabList from './tab-list';
+import TabPanels from './tab-panels';
+
+export default class Tabs extends React.Component {
+  constructor() {
+    super();
+    this.accessibleId = uniqueId('rac-tabs-')
+  }
+
+  render() {
+    const { activeIndex, children, className, onActivateTab } = this.props;
+    const accessibleId = this.accessibleId;
+
+    return (
+      <div className={className}>
+        {React.Children.map(children, (child) => {
+          if (!child) { return child; }
+
+          switch (child.type) {
+            case TabList:
+              return React.cloneElement(child, { accessibleId, activeIndex, onActivateTab });
+            case TabPanels:
+              return React.cloneElement(child, { accessibleId, activeIndex });
+            default:
+              return child;
+          }
+        })}
+      </div>
+    );
+  }
+}
+
+Tabs.propTypes = {
+  activeIndex: PropTypes.number.isRequired,
+  children: PropTypes.node,
+  className: PropTypes.string,
+  onActivateTab: PropTypes.func,
+};
+
+Tabs.defaultProps = {
+  children: null,
+  className: undefined,
+  onActivateTab: () => {},
+};

--- a/src/utils/unique-id.js
+++ b/src/utils/unique-id.js
@@ -1,0 +1,6 @@
+let counter = 0;
+
+export default function uniqueId() {
+  counter++;
+  return `$rac$${counter}`;
+}


### PR DESCRIPTION
**_Not ready for primetime_**, yet, and this is a straight-up port from Mavenlink of the Tabs component. There are a couple things to resolve with the implementation and philosophically, first.

#### Implementation:
- No styles are being applied yet.
- Class properties are not being used, hence all of the `bind`-ing.
- This doesn't handle nested tabs. For example, something like:
   ```jsx
   <TabList>
     <Tab>Stuff</Tab> // <- Works
     <div>
        <Tab>Other STuff</Tab> // <- Does not work
     </div>
   </TabList>
   ```
   Which can be useful for mixing in other things like buttons and using flex to put tabs on one side, buttons on the other.
- Uses old school refs to manually focus an element. Kind of unfortunate, but per the spec we have to manually manage focus when using the arrow keys to change the tab.
- Does not handle vertical tabs, which require different keys (up and down vs left and right).
- Needs some docs

#### Philosophical:
- ~~Are we cool with bringing in a 3rd-party dependency? A lot of accessibility things require IDs, and we need a way to generate unique ones. I brought in lodash.uniqueid for that.~~
- How much styling should we provide here?
- Should we bring in https://babeljs.io/docs/en/babel-plugin-transform-class-properties/ and use class properties? Doesn't matter for now, but the current implementation of tabs would be cleaned up a lot.
- Are we okay with some of these components keeping internal state? I'm not opposed, although the current use case for it in tabs may not be necessary if we can come up with a better way of managing tab focus.

If you're game @juanca , I'd recommend us pairing on next week:

- Going through the tabs spec and verifying that we've covered all the bases
- Seeing if we can come up with alternative ways of managing focus here

As I said, this thing isn't ready for primetime, yet, but I'm pretty happy with the API. Let's work on resolving the above issues sometime.