### PR TITLE
Tabs updates

### DIFF
--- a/src/examples/tabs-example.js
+++ b/src/examples/tabs-example.js
@@ -21,7 +21,7 @@ export default class TabsExample extends React.Component {
             <Tab>Burritos</Tab>
             <Tab>Churros</Tab>
           </TabList>
-          <TabPanels>
+          <TabPanels hasFocusableContent={false}>
             <div>Delicious!</div>
             <div>Just big tacos</div>
             <div>Mmmmmmmmmmm...</div>

--- a/src/tab-list.js
+++ b/src/tab-list.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import Tab from './tab.js';
 import styles from './tab-list.css';
 
 export default class TabList extends React.Component {
@@ -55,6 +56,10 @@ export default class TabList extends React.Component {
     return (
       <ul className={className} onKeyUp={this.handleKeyPress} role="tablist">
         {React.Children.map(children, (child, index) => {
+          if (child.type !== Tab) {
+            throw new Error('Direct children of a <TabList> must be a <Tab>');
+          }
+
           const active = index === activeIndex;
           const tabRef = this.tabRefs[index];
 

--- a/src/tab-panels.js
+++ b/src/tab-panels.js
@@ -1,7 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-export default function TabPanels({ accessibleId, activeIndex, children, className }) {
+export default function TabPanels({
+  accessibleId,
+  activeIndex,
+  children,
+  className,
+  hasFocusableContent,
+}) {
   return (
     <div
       aria-labelledby={accessibleId}

--- a/src/tab-panels.js
+++ b/src/tab-panels.js
@@ -7,6 +7,7 @@ export default function TabPanels({ accessibleId, activeIndex, children, classNa
       aria-labelledby={accessibleId}
       role="tabpanel"
       className={className}
+      tabIndex={hasFocusableContent ? undefined : 0}
     >
       {React.Children.toArray(children)[activeIndex]}
     </div>
@@ -18,10 +19,12 @@ TabPanels.propTypes = {
   activeIndex: PropTypes.number,
   children: PropTypes.node,
   className: PropTypes.string,
+  hasFocusableContent: PropTypes.bool,
 };
 
 TabPanels.defaultProps = {
   accessibleId: undefined,
   activeIndex: 0,
   className: null,
+  hasFocusableContent: false,
 };

--- a/src/tab-panels.js
+++ b/src/tab-panels.js
@@ -25,12 +25,11 @@ TabPanels.propTypes = {
   activeIndex: PropTypes.number,
   children: PropTypes.node,
   className: PropTypes.string,
-  hasFocusableContent: PropTypes.bool,
+  hasFocusableContent: PropTypes.bool.isRequired,
 };
 
 TabPanels.defaultProps = {
   accessibleId: undefined,
   activeIndex: 0,
   className: null,
-  hasFocusableContent: false,
 };

--- a/src/tab-panels.js
+++ b/src/tab-panels.js
@@ -3,7 +3,11 @@ import React from 'react';
 
 export default function TabPanels({ accessibleId, activeIndex, children, className }) {
   return (
-    <div aria-labelledby={accessibleId} role="tabpanel" className={className}>
+    <div
+      aria-labelledby={accessibleId}
+      role="tabpanel"
+      className={className}
+    >
       {React.Children.toArray(children)[activeIndex]}
     </div>
   );


### PR DESCRIPTION
This PR:

1. Enforces tablist children as being tabs.

   Right now our focus-management for the tablist breaks if actual DOM elements are used (as opposed to React components), and we need either more sophisticated management of focus or a restriction on what children the tablist can have.

   My thought is that the focus management is complex enough as it is, and there's not a lot of gain to allowing arbitrary children (as much as I love the idea for its flexibility).

2. Adds a prop to set whether or not the tab panel has focusable content or not,  based off of https://github.com/w3c/aria-practices/issues/323#issuecomment-400011586. Also resolves https://github.com/juanca/react-aria-components/issues/7.

   If there is no focusable content, per the [w3c authoring practices](https://www.w3.org/TR/wai-aria-practices-1.1/#tabpanel), the tab panel should receive focus. Otherwise, it should not.