### PR TITLE
Try Ref Forwarding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8287,9 +8287,9 @@
       }
     },
     "react": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.4.0.tgz",
-      "integrity": "sha512-K0UrkLXSAekf5nJu89obKUM7o2vc6MMN9LYoKnCa+c+8MJRAT120xzPLENcWSRc7GYKIg0LlgJRDorrufdglQQ==",
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.4.1.tgz",
+      "integrity": "sha512-3GEs0giKp6E0Oh/Y9ZC60CmYgUPnp7voH9fbjWsvXtYFb4EWtgQub0ADSq0sJR0BbHc4FThLLtzlcFaFXIorwg==",
       "dev": true,
       "requires": {
         "fbjs": "^0.8.16",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "html-webpack-plugin": "^3.2.0",
     "mini-css-extract-plugin": "^0.4.0",
     "prop-types": "^15.6.1",
-    "react": "^16.4.0",
+    "react": "^16.4.1",
     "react-dom": "^16.4.0",
     "webpack": "^4.8.3",
     "webpack-cli": "^2.1.4",

--- a/src/tab-list.js
+++ b/src/tab-list.js
@@ -61,13 +61,13 @@ export default class TabList extends React.Component {
           }
 
           const active = index === activeIndex;
-          const tabRef = this.tabRefs[index];
+          const ref = this.tabRefs[index];
 
           return React.cloneElement(child, {
             accessibleId: active ? accessibleId : undefined,
             active,
-            tabRef,
             onActivate: () => this.props.onActivateTab(index),
+            ref,
           });
         })}
       </ul>

--- a/src/tab.js
+++ b/src/tab.js
@@ -2,28 +2,27 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styles from './tab.css';
 
-export default function Tab({
+const Tab = React.forwardRef(({
   accessibleId,
   active,
   children,
   className,
   onActivate,
-  tabRef,
-}) {
+}, ref) => {
   return (
     <li
       aria-selected={active}
       className={className}
       id={accessibleId}
       onClick={onActivate}
-      ref={tabRef}
+      ref={ref}
       role="tab"
       tabIndex={active ? 0 : undefined}
     >
       {children}
     </li>
   );
-}
+});
 
 Tab.propTypes = {
   accessibleId: PropTypes.string,
@@ -31,7 +30,6 @@ Tab.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   onActivate: PropTypes.func,
-  tabRef: PropTypes.object,
 };
 
 Tab.defaultProps = {
@@ -39,5 +37,6 @@ Tab.defaultProps = {
   active: false,
   className: styles.container,
   onActivate: undefined,
-  tabRef: undefined,
 };
+
+export default Tab;


### PR DESCRIPTION
Try out the new [React forwardRef API](https://reactjs.org/docs/forwarding-refs.html#forwarding-refs-to-dom-components).

I don't like it as much as what we were doing here, but I'm having a hell of a time using the Tabs component in other libraries. Even though our examples work fine here, in another project React thinks that we're putting refs onto stateless components.

We're not, but I figured it wouldn't hurt to check if using this new API resolves the issue.