### PR TITLE
Babel configuration for targeted browsers

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,7 @@
     ["env", {
       "targets": {
         "browsers": [
+          "IE 11",
           "last 5 Chrome versions",
           "last 5 Firefox versions",
           "last 5 Safari versions",

--- a/.babelrc
+++ b/.babelrc
@@ -9,7 +9,8 @@
           "last 5 Safari versions",
           "last 5 Edge versions"
         ]
-      }
+      },
+      "useBuiltins": true
     }],
     "react"
   ]

--- a/.babelrc
+++ b/.babelrc
@@ -3,10 +3,10 @@
     ["env", {
       "targets": {
         "browsers": [
-          "last 1 Chrome versions",
-          "last 1 Firefox versions",
-          "last 1 Safari versions",
-          "last 1 Edge versions"
+          "last 5 Chrome versions",
+          "last 5 Firefox versions",
+          "last 5 Safari versions",
+          "last 5 Edge versions"
         ]
       }
     }],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1323,6 +1323,25 @@
         "babel-types": "^6.24.1"
       }
     },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
+        }
+      }
+    },
     "babel-preset-env": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-aria-components",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.4",
+    "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
     "css-loader": "^0.28.11",

--- a/src/examples/index.js
+++ b/src/examples/index.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill';
 import React from 'react';
 import { render } from 'react-dom';
 


### PR DESCRIPTION
This is especially important for IE 11.

The polyfills are only used in the examples page. In addition, `useBuiltins` will *not* bundle redundant polyfills for really old browsers.