### PR TITLE
Grid UX: keyboard navigation while in interactive mode

### DIFF
--- a/src/examples/grid-cells/fancy-input-grid-cell.js
+++ b/src/examples/grid-cells/fancy-input-grid-cell.js
@@ -106,7 +106,7 @@ class FancyInputGridCell extends React.Component {
         break;
       }
       default: {
-        if (this.state.interactive) {
+        if (this.state.interactive && /Arrow/.test(event.key)) {
           // Do not use native keyboard navigation while interactive
           event.preventDefault();
           // Do not use grid keyboard navigation while interactive

--- a/src/examples/grid-cells/fancy-input-grid-cell.js
+++ b/src/examples/grid-cells/fancy-input-grid-cell.js
@@ -84,21 +84,24 @@ class FancyInputGridCell extends React.Component {
         break;
       }
       case 'Tab': {
-        const nextCell = event.shiftKey ? this.props.minusX : this.props.plusX;
+        if (this.state.interactive) {
+          const nextCell = event.shiftKey ? this.props.minusX : this.props.plusX;
 
-        if (nextCell === this.props.gridCellRef) {
-          this.setState({
-            interactive: false,
-          });
-        } else {
-          this.setState({
-            interactive: false,
-            wasTabbed: true,
-          });
-          nextCell.current.focus();
+          if (nextCell === this.props.gridCellRef) {
+            this.setState({
+              interactive: false,
+            });
+          } else {
+            this.setState({
+              interactive: false,
+              wasTabbed: true,
+            });
+            nextCell.current.focus();
+          }
+
+          event.preventDefault();
         }
 
-        event.preventDefault();
         break;
       }
       default: {

--- a/src/examples/grid-cells/fancy-input-grid-cell.js
+++ b/src/examples/grid-cells/fancy-input-grid-cell.js
@@ -57,7 +57,26 @@ class FancyInputGridCell extends React.Component {
   onKeyDown(event) {
     switch (event.key) {
       case 'Enter': {
-        this.setState(state => ({ interactive: !state.interactive }));
+        if (this.state.interactive) {
+          const nextCell = event.shiftKey ? this.props.minusY : this.props.plusY;
+
+          if (nextCell === this.props.gridCellRef) {
+            this.setState({
+              interactive: false,
+            });
+          } else {
+            this.setState({
+              interactive: false,
+              wasTabbed: true,
+            });
+            nextCell.current.focus();
+          }
+        } else {
+          this.setState({
+            interactive: true,
+          });
+        }
+
         break;
       }
       case 'Escape': {
@@ -143,8 +162,16 @@ function getMinusX(refs, x, y) {
   return refs[y][Math.max(x - 1, 0)];
 }
 
+function getMinusY(refs, x, y) {
+  return refs[Math.max(y - 1, 0)][x];
+}
+
 function getPlusX(refs, x, y) {
   return refs[y][Math.min(x + 1, refs[0].length - 1)];
+}
+
+function getPlusY(refs, x, y) {
+  return refs[Math.min(y + 1, refs.length - 1)][x];
 }
 
 export default function FocusableFancyInputGridCell(props) {
@@ -160,7 +187,9 @@ export default function FocusableFancyInputGridCell(props) {
           {...props}
           gridCellRef={gridRefs[idY][idX]}
           minusX={getMinusX(gridRefs, idX, idY)}
+          minusY={getMinusY(gridRefs, idX, idY)}
           plusX={getPlusX(gridRefs, idX, idY)}
+          plusY={getPlusY(gridRefs, idX, idY)}
         />
       )}
     </GridContext.Consumer>

--- a/src/examples/grid-cells/fancy-input-grid-cell.js
+++ b/src/examples/grid-cells/fancy-input-grid-cell.js
@@ -13,6 +13,7 @@ class FancyInputGridCell extends React.Component {
     this.state = {
       interactive: false,
       value: props.defaultValue,
+      wasTabbed: false,
     };
 
     this.onBlur = this.onBlur.bind(this);
@@ -26,8 +27,14 @@ class FancyInputGridCell extends React.Component {
       this.inputRef.current.focus();
     }
 
-    if (state.interactive && !this.state.interactive) {
+    if (state.interactive && !this.state.interactive && !this.state.wasTabbed) {
       this.props.gridCellRef.current.focus();
+    }
+
+    if (this.state.wasTabbed) {
+      // Immediately unset the tab flag to avoid infinite updates.
+      // The flag should only ever be set in one place -- interactive mode + tab press.
+      this.setState({ wasTabbed: false }); // eslint-disable-line react/no-did-update-set-state
     }
   }
 
@@ -55,6 +62,24 @@ class FancyInputGridCell extends React.Component {
       }
       case 'Escape': {
         this.setState({ interactive: false });
+        break;
+      }
+      case 'Tab': {
+        const nextCell = event.shiftKey ? this.props.minusX : this.props.plusX;
+
+        if (nextCell === this.props.gridCellRef) {
+          this.setState({
+            interactive: false,
+          });
+        } else {
+          this.setState({
+            interactive: false,
+            wasTabbed: true,
+          });
+          nextCell.current.focus();
+        }
+
+        event.preventDefault();
         break;
       }
       default: {
@@ -108,7 +133,19 @@ FancyInputGridCell.defaultProps = {
 FancyInputGridCell.propTypes = {
   defaultValue: PropTypes.string.isRequired,
   gridCellRef: RefType.isRequired,
+  minusX: RefType.isRequired,
+  minusY: RefType.isRequired,
+  plusX: RefType.isRequired,
+  plusY: RefType.isRequired,
 };
+
+function getMinusX(refs, x, y) {
+  return refs[y][Math.max(x - 1, 0)];
+}
+
+function getPlusX(refs, x, y) {
+  return refs[y][Math.min(x + 1, refs[0].length - 1)];
+}
 
 export default function FocusableFancyInputGridCell(props) {
   const {
@@ -118,7 +155,14 @@ export default function FocusableFancyInputGridCell(props) {
 
   return (
     <GridContext.Consumer>
-      {gridRefs => <FancyInputGridCell {...props} gridCellRef={gridRefs[idY][idX]} />}
+      {gridRefs => (
+        <FancyInputGridCell
+          {...props}
+          gridCellRef={gridRefs[idY][idX]}
+          minusX={getMinusX(gridRefs, idX, idY)}
+          plusX={getPlusX(gridRefs, idX, idY)}
+        />
+      )}
     </GridContext.Consumer>
   );
 }

--- a/src/examples/grid-cells/fancy-input-grid-cell.js
+++ b/src/examples/grid-cells/fancy-input-grid-cell.js
@@ -107,8 +107,6 @@ class FancyInputGridCell extends React.Component {
       }
       default: {
         if (this.state.interactive && /Arrow/.test(event.key)) {
-          // Do not use native keyboard navigation while interactive
-          event.preventDefault();
           // Do not use grid keyboard navigation while interactive
           event.stopPropagation();
         }

--- a/src/examples/grid-cells/fancy-input-grid-cell.js
+++ b/src/examples/grid-cells/fancy-input-grid-cell.js
@@ -105,8 +105,10 @@ class FancyInputGridCell extends React.Component {
         break;
       }
       default: {
-        // Do not use keyboard navigation while interactive
         if (this.state.interactive) {
+          // Do not use native keyboard navigation while interactive
+          event.preventDefault();
+          // Do not use grid keyboard navigation while interactive
           event.stopPropagation();
         }
 

--- a/src/examples/grid-cells/fancy-input-grid-cell.js
+++ b/src/examples/grid-cells/fancy-input-grid-cell.js
@@ -13,7 +13,7 @@ class FancyInputGridCell extends React.Component {
     this.state = {
       interactive: false,
       value: props.defaultValue,
-      wasTabbed: false,
+      wasEscaped: false,
     };
 
     this.onBlur = this.onBlur.bind(this);
@@ -27,14 +27,14 @@ class FancyInputGridCell extends React.Component {
       this.inputRef.current.focus();
     }
 
-    if (state.interactive && !this.state.interactive && !this.state.wasTabbed) {
+    if (state.interactive && !this.state.interactive && this.state.wasEscaped) {
       this.props.gridCellRef.current.focus();
     }
 
-    if (this.state.wasTabbed) {
+    if (this.state.wasEscaped) {
       // Immediately unset the tab flag to avoid infinite updates.
       // The flag should only ever be set in one place -- interactive mode + tab press.
-      this.setState({ wasTabbed: false }); // eslint-disable-line react/no-did-update-set-state
+      this.setState({ wasEscaped: false }); // eslint-disable-line react/no-did-update-set-state
     }
   }
 
@@ -67,7 +67,6 @@ class FancyInputGridCell extends React.Component {
           } else {
             this.setState({
               interactive: false,
-              wasTabbed: true,
             });
             nextCell.current.focus();
           }
@@ -80,7 +79,10 @@ class FancyInputGridCell extends React.Component {
         break;
       }
       case 'Escape': {
-        this.setState({ interactive: false });
+        this.setState({
+          interactive: false,
+          wasEscaped: true,
+        });
         break;
       }
       case 'Tab': {
@@ -94,7 +96,6 @@ class FancyInputGridCell extends React.Component {
           } else {
             this.setState({
               interactive: false,
-              wasTabbed: true,
             });
             nextCell.current.focus();
           }

--- a/src/grid/grid-cell.css
+++ b/src/grid/grid-cell.css
@@ -10,3 +10,7 @@
 .container:first-child {
   border-left: 1px solid black;
 }
+
+.container[tabindex="0"] {
+  z-index: 1;
+}

--- a/src/grid/grid-cell.js
+++ b/src/grid/grid-cell.js
@@ -16,7 +16,7 @@ class GridCell extends React.Component {
     this.onKeyDown = this.onKeyDown.bind(this);
 
     this.state = {
-      tabIndex: this.props.gridCellRefs[0][0] === this.props.gridCellRef ? 0 : -1,
+      tabIndex: -1,
     };
   }
 

--- a/src/grid/grid.css
+++ b/src/grid/grid.css
@@ -1,3 +1,4 @@
 .container {
   position: relative;
+  transform: translate3d(0, 0, 0);
 }

--- a/src/grid/grid.js
+++ b/src/grid/grid.js
@@ -14,7 +14,7 @@ export default class Grid extends React.Component {
       columnIndex: 0,
     };
 
-    this.onClick = this.onClick.bind(this);
+    this.onFocus = this.onFocus.bind(this);
     this.onKeyDown = this.onKeyDown.bind(this);
   }
 
@@ -22,7 +22,7 @@ export default class Grid extends React.Component {
     this.props.gridRefs[this.state.rowIndex][this.state.columnIndex].current.focus();
   }
 
-  onClick(event) {
+  onFocus(event) {
     let newColumnIndex;
     const newRowIndex = this.props.gridRefs.findIndex((rows) => {
       newColumnIndex = rows.findIndex(cellRef => cellRef.current === event.target);
@@ -84,7 +84,7 @@ export default class Grid extends React.Component {
         <div // eslint-disable-line jsx-a11y/interactive-supports-focus
           className={this.props.className}
           role="grid"
-          onClick={this.onClick}
+          onFocus={this.onFocus}
           onKeyDown={this.onKeyDown}
         >
           {this.props.children}

--- a/src/grid/grid.js
+++ b/src/grid/grid.js
@@ -10,8 +10,8 @@ export default class Grid extends React.Component {
     super(props);
 
     this.state = {
-      rowIndex: 0,
-      columnIndex: 0,
+      rowIndex: -1,
+      columnIndex: -1,
     };
 
     this.onFocus = this.onFocus.bind(this);
@@ -44,6 +44,7 @@ export default class Grid extends React.Component {
       case 'ArrowDown': {
         event.preventDefault();
         this.setState(state => ({
+          columnIndex: Math.max(state.columnIndex, 0),
           rowIndex: Math.min(state.rowIndex + 1, this.props.gridRefs.length - 1),
         }));
 
@@ -53,6 +54,7 @@ export default class Grid extends React.Component {
         event.preventDefault();
         this.setState(state => ({
           columnIndex: Math.max(state.columnIndex - 1, 0),
+          rowIndex: Math.max(state.rowIndex, 0),
         }));
 
         return true;
@@ -61,6 +63,7 @@ export default class Grid extends React.Component {
         event.preventDefault();
         this.setState(state => ({
           columnIndex: Math.min(state.columnIndex + 1, this.props.gridRefs[0].length - 1),
+          rowIndex: Math.max(state.rowIndex, 0),
         }));
 
         return true;
@@ -68,6 +71,7 @@ export default class Grid extends React.Component {
       case 'ArrowUp': {
         event.preventDefault();
         this.setState(state => ({
+          columnIndex: Math.max(state.columnIndex, 0),
           rowIndex: Math.max(state.rowIndex - 1, 0),
         }));
 
@@ -86,6 +90,7 @@ export default class Grid extends React.Component {
           role="grid"
           onFocus={this.onFocus}
           onKeyDown={this.onKeyDown}
+          tabIndex="0"
         >
           {this.props.children}
         </div>

--- a/src/grid/row-headers.css
+++ b/src/grid/row-headers.css
@@ -2,5 +2,5 @@
   composes: container from './row.css';
   position: sticky;
   top: 0;
-  z-index: 1;
+  z-index: 2;
 }


### PR DESCRIPTION
# Motivation

1. There are too (two) many keystrokes in the following workflow: edit a cell; navigate to adjacent cell; edit the cell.
2. There exists a precedence for navigating between "cells" via `<tab>` and `<enter>` (along with the `<shift>` modifier key) in other grid-based interfaces

# Changes

Given that a cell knows about its own reference, it also consumes the references to adjacent cells. Upon the appropriate key strokes, it focuses the appropriate adjacent cell -- exactly how `<Grid>` manages arrow navigation. 

There is some duplication between `<FancyInputGridCell>` and `<InteractiveGridCell>`. There is also some duplication between `<FancyInputGridCell>` and `<Grid>`. I would like to focus on improving these two aspects of the codebase. The solution might involve an overhaul in the architecture of the Grid and its related components. Given that particular risk, I will make it its own PR as this is just a proof of concept for better UX.