### PR TITLE
Update Ref Proptype

### DIFF
--- a/src/prop-types/ref.js
+++ b/src/prop-types/ref.js
@@ -1,5 +1,3 @@
 import PropTypes from 'prop-types';
 
-export default PropTypes.shape({
-  current: PropTypes.any,
-});
+export default PropTypes.object;

--- a/src/prop-types/ref.js
+++ b/src/prop-types/ref.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
 
 export default PropTypes.shape({
-  value: PropTypes.any,
+  current: PropTypes.any,
 });


### PR DESCRIPTION
[Per the React docs](https://reactjs.org/docs/refs-and-the-dom.html#accessing-refs), refs have a `current` property, and this PR updates our custom prop type.