### PR TITLE
`npm ci`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8.11.1
+      - image: circleci/node:8.15
     working_directory: ~/repo
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ jobs:
       - restore_cache:
           keys:
           - node_modules-1-{{ checksum "package.json" }}-{{ checksum "package-lock.json"}}
+          - node_modules-1-{{ checksum "package.json" }}
           - node_modules-1-
       - run: npm ci
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:7.10
+      - image: circleci/node:8.11.1
     working_directory: ~/repo
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,6 @@ jobs:
       - save_cache:
           paths:
             - node_modules
-          key: node_modules-1-{{ checksum "package.json" }}
+          key: node_modules-1-{{ checksum "package.json" }}-{{ checksum "package-lock.json"}}
       - run: npm run lint
       - run: npm test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           keys:
           - node_modules-1-{{ checksum "package.json" }}-{{ checksum "package-lock.json"}}
           - node_modules-1-
-      - run: npm install
+      - run: npm ci
       - save_cache:
           paths:
             - node_modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,13 +8,13 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-          - node_modules-1-{{ checksum "package.json" }}-{{ checksum "package-lock.json"}}
-          - node_modules-1-{{ checksum "package.json" }}
-          - node_modules-1-
+          - node_modules-2-{{ checksum "package.json" }}-{{ checksum "package-lock.json"}}
+          - node_modules-2-{{ checksum "package.json" }}
+          - node_modules-2-
       - run: npm ci
       - save_cache:
           paths:
-            - node_modules
-          key: node_modules-1-{{ checksum "package.json" }}-{{ checksum "package-lock.json"}}
+            - $HOME/.npm
+          key: node_modules-2-{{ checksum "package.json" }}-{{ checksum "package-lock.json"}}
       - run: npm run lint
       - run: npm test


### PR DESCRIPTION
Documentation: https://docs.npmjs.com/cli/ci.html

I knew Yarn had a similar feature and I wanted to reproduce it in this project. This ensures PRs will have appropriate changes to the `package-lock.json` file: `npm ci` will fail CI if it needs to change the lockfile.

> If dependencies in the package lock do not match those in `package.json`, `npm ci` will exit with an error, instead of updating the package lock.

However, 

> If a `node_modules` is already present, it will be automatically removed before `npm ci` begins its install.

which implies we need to cache `$HOME/.npm` instead of the `node_modules` folder.