### PR TITLE
Fix prop-type validation errors on Grid example

### DIFF
--- a/src/grid/data-grid.test.js
+++ b/src/grid/data-grid.test.js
@@ -2,6 +2,8 @@ import React from 'react';
 import TestRenderer from 'react-test-renderer';
 
 import DataGrid from './data-grid.js';
+import GridCell from './grid-cell.js';
+import GridRow from './grid-row.js';
 
 function render(props) {
   const refs = [];
@@ -32,4 +34,25 @@ test('has a className property', () => {
   const root = renderer.toJSON();
 
   expect(root.props.className).toStrictEqual('part-of-the-api');
+});
+
+describe('end-to-end grid components', () => {
+  it('does not have prop-type validation errors', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    TestRenderer.create((
+      <DataGrid refs={[]}>
+        <GridRow>
+          <GridCell>{() => 'I am the'}</GridCell>
+          <GridCell>{() => 'first row'}</GridCell>
+        </GridRow>
+        <GridRow>
+          <GridCell>{() => 'I am the'}</GridCell>
+          <GridCell>{() => 'second row'}</GridCell>
+        </GridRow>
+      </DataGrid>
+    ));
+
+    expect(console.error).not.toHaveBeenCalled(); // eslint-disable-line no-console
+  });
 });

--- a/src/grid/data-grid.test.js
+++ b/src/grid/data-grid.test.js
@@ -43,12 +43,12 @@ describe('end-to-end grid components', () => {
     TestRenderer.create((
       <DataGrid refs={[]}>
         <GridRow>
-          <GridCell>{() => 'I am the'}</GridCell>
-          <GridCell>{() => 'first row'}</GridCell>
+          <GridCell cellRef={React.createRef()}>{() => 'I am the'}</GridCell>
+          <GridCell cellRef={React.createRef()}>{() => 'first row'}</GridCell>
         </GridRow>
         <GridRow>
-          <GridCell>{() => 'I am the'}</GridCell>
-          <GridCell>{() => 'second row'}</GridCell>
+          <GridCell cellRef={React.createRef()}>{() => 'I am the'}</GridCell>
+          <GridCell cellRef={React.createRef()}>{() => 'second row'}</GridCell>
         </GridRow>
       </DataGrid>
     ));

--- a/src/grid/grid-cell.js
+++ b/src/grid/grid-cell.js
@@ -32,7 +32,7 @@ export default class GridCell extends React.Component {
 }
 
 GridCell.propTypes = {
-  active: PropTypes.bool.isRequired,
+  active: PropTypes.bool,
   cellRef: RefType.isRequired,
   children: PropTypes.func.isRequired,
   className: PropTypes.string,
@@ -40,6 +40,7 @@ GridCell.propTypes = {
 };
 
 GridCell.defaultProps = {
+  active: false,
   className: undefined,
   header: false,
 };

--- a/src/grid/grid-cell.test.js
+++ b/src/grid/grid-cell.test.js
@@ -7,7 +7,7 @@ function render(props) {
   const cellRef = React.createRef();
 
   return TestRenderer.create((
-    <GridCell active={false} cellRef={cellRef} {...props}>
+    <GridCell cellRef={cellRef} {...props}>
       {active => (
         `Cell is ${active ? 'active' : 'inactive'}`
       )}

--- a/src/grid/grid-row.js
+++ b/src/grid/grid-row.js
@@ -28,12 +28,14 @@ export default class Row extends React.Component {
 }
 
 Row.propTypes = {
-  active: PropTypes.bool.isRequired,
-  cellIndex: PropTypes.number.isRequired,
+  active: PropTypes.bool,
+  cellIndex: PropTypes.number,
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
 };
 
 Row.defaultProps = {
+  active: false,
+  cellIndex: -1,
   className: undefined,
 };

--- a/src/grid/grid-row.test.js
+++ b/src/grid/grid-row.test.js
@@ -5,7 +5,7 @@ import GridRow from './grid-row.js';
 
 function render(props) {
   return TestRenderer.create((
-    <GridRow active={false} cellIndex={-1} {...props}>
+    <GridRow {...props}>
       <div>I am the first cell</div>
       <div>I am the second cell</div>
     </GridRow>
@@ -17,6 +17,8 @@ test('renders the default state', () => {
   const root = renderer.toJSON();
 
   expect(root.children.length).toStrictEqual(2);
+  expect(root.children[0].props.active).toStrictEqual(false);
+  expect(root.children[1].props.active).toStrictEqual(false);
   expect(root.props.className).toStrictEqual(undefined);
   expect(root.props.role).toStrictEqual('row');
   expect(root.props.style.display).toStrictEqual('flex');


### PR DESCRIPTION
Closes https://github.com/juanca/react-aria-components/issues/60

- Implement failing test for missing props on Grid example
- Refactoring: ???

Note: Normally, I would prefer each test to also render an end-to-end Grid but it seems to be too noisy. I wonder if we can extrapolate this pattern?