### PR TITLE
Configure `import/extensions` to always be explicit except for packages

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,9 @@
     "plugin:jest/recommended"
   ],
   "rules": {
-    "import/extensions": "off",
+    "import/extensions": ["error", "always", {
+      "ignorePackages": true
+    }],
     "max-len": ["error", {
       "ignoreTrailingComments": true
     }],

--- a/pages/accordions/example-1.js
+++ b/pages/accordions/example-1.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Example from '../example.js';
-import { Accordion, Section } from '../../src/accordion';
+import { Accordion, Section } from '../../src/accordion/index.js';
 
 function CustomTitle({ open, title }) { // eslint-disable-line react/prop-types
   return (

--- a/pages/tabs/example-1.js
+++ b/pages/tabs/example-1.js
@@ -6,7 +6,7 @@ import {
   TabList,
   Tab,
   TabPanels,
-} from '../../src/tabs';
+} from '../../src/tabs/index.js';
 
 export default class TabsExample extends React.Component {
   constructor() {

--- a/src/grid/data-grid.js
+++ b/src/grid/data-grid.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import Cursor from '../cursor';
+import Cursor from '../cursor/index.js';
 import RefType from '../prop-types/ref.js';
 
 export default function Grid(props) {

--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import uniqueId from '../utils/unique-id';
-import TabList from './tab-list';
-import TabPanels from './tab-panels';
+import uniqueId from '../utils/unique-id.js';
+import TabList from './tab-list.js';
+import TabPanels from './tab-panels.js';
 
 export default class Tabs extends React.Component {
   constructor() {


### PR DESCRIPTION
While it is nice to auto-resolve `./index.js` and `*.js`, I think it will provide simpler static analysis to always specify the file and its extension.

Closes: https://github.com/juanca/react-aria-components/issues/23