### PR TITLE
Improve reliability of creating per-branch Github pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,4 +68,3 @@ jobs:
             git diff-index --quiet HEAD || git commit -m 'Update Github pages'
             git push origin gh-pages
       - run: echo https://juanca.github.io/react-aria-components/$CIRCLE_BRANCH/
-      - run: ls $CIRCLE_BRANCH

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,8 @@ jobs:
             npm run compile
             git checkout gh-pages
             rm -rf $CIRCLE_BRANCH
-            mv dist $CIRCLE_BRANCH
+            mkdir -p $CIRCLE_BRANCH
+            mv -v dist/* $CIRCLE_BRANCH
             git add .
             git diff-index --quiet HEAD || git commit -m 'Update Github pages'
             git push origin gh-pages


### PR DESCRIPTION
Two changes:

1. Make any intermediary folders for cases with complex branch names (I'm looking at you dependabot)
2. Verbose output from moving things around